### PR TITLE
fix: include `--remote` flag in branch listing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ where
 
 pub fn list_branches_cmd(config: impl FnOnce(&mut Command) -> &mut Command) -> EasyCommand {
     EasyCommand::new_with("git", |cmd| {
-        config(cmd.args(["branch", "--list", "--format=%(refname:short)"]))
+        config(cmd.args(["branch", "--list", "--remote", "--format=%(refname:short)"]))
     })
 }
 


### PR DESCRIPTION
This lets folks select branches that may be only present in remotes.